### PR TITLE
docs: clarify that prettier plugins must be explicitly enabled

### DIFF
--- a/packages/autocorrect/README.md
+++ b/packages/autocorrect/README.md
@@ -29,8 +29,15 @@ yarn add -D prettier prettier-plugin-autocorrect
 
 ## Usage
 
-Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) should be automatically recognized by Prettier. To use this plugin, confirm that it's installed and run Prettier using your preferred method. For example:
+Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) must be added to `.prettierrc`:
 
+```json
+{
+  "plugins": ["prettier-plugin-autocorrect"]
+}
+```
+
+Then:
 ```sh
 # npx
 npx prettier --write writing.md

--- a/packages/pkg/README.md
+++ b/packages/pkg/README.md
@@ -24,8 +24,15 @@ yarn add -D prettier prettier-plugin-pkg
 
 ## Usage
 
-Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) should be automatically recognized by Prettier. To use this plugin, confirm that it's installed and run Prettier using your preferred method. For example:
+Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) must be added to `.prettierrc`:
 
+```json
+{
+  "plugins": ["prettier-plugin-pkg"]
+}
+```
+
+Then:
 ```sh
 # npx
 npx prettier --write package.json

--- a/packages/sh/README.md
+++ b/packages/sh/README.md
@@ -33,8 +33,15 @@ yarn add -D prettier prettier-plugin-sh
 
 ## Usage
 
-Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) should be automatically recognized by Prettier. To use this plugin, confirm that it's installed and run Prettier using your preferred method. For example:
+Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) must be added to `.prettierrc`:
 
+```json
+{
+  "plugins": ["prettier-plugin-sh"]
+}
+```
+
+Then:
 ```sh
 # npx
 npx prettier --write script.sh

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -29,8 +29,14 @@ yarn add -D prettier prettier-plugin-sql
 
 ## Usage
 
-Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) should be automatically recognized by Prettier. To use this plugin, confirm that it's installed and run Prettier using your preferred method. For example:
+Once installed, [Prettier plugins](https://prettier.io/docs/en/plugins.html) must be added to `.prettierrc`:
 
+```json
+{
+  "plugins": ["prettier-plugin-sql"]
+}
+```
+Then:
 ```sh
 # npx
 npx prettier --write db.sql


### PR DESCRIPTION
It's possible that auto-enabling all plugins was a previous feature, but it's not the case currently.