### PR TITLE
docs: add usage section about `prettier-plugin-embed`

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -47,6 +47,68 @@ npx prettier --write db.sql
 yarn prettier --write db.sql
 ```
 
+### SQL-in-JS with `prettier-plugin-embed`
+
+
+### Config Examples
+
+#### `prettier-plugin-sql` and `sql-formatter`
+
+Format SQL-in-JS tagged template literals by installing [`prettier-plugin-embed`](https://github.com/Sec-ant/prettier-plugin-embed) and configuring as follows:
+
+`prettier.config.mjs`
+
+```js
+/** @type {import('prettier').Config} */
+const prettierConfig = {
+  plugins: ['prettier-plugin-embed', 'prettier-plugin-sql'],
+};
+
+/** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
+const prettierPluginEmbedConfig = {
+  embeddedSqlIdentifiers: ['sql'],
+}
+
+/** @type {import('prettier-plugin-sql').SqlBaseOptions} */
+const prettierPluginSqlConfig = {
+  language: 'postgresql',
+  keywordCase: 'upper',
+}
+
+const config = {
+  ...prettierConfig,
+  ...prettierPluginEmbedConfig,
+  ...prettierPluginSqlConfig,
+};
+
+export default config;
+```
+
+Before formatting:
+
+```ts
+const animals = await sql`
+  sELect  first_name,    species froM
+   animals
+         WhERE
+ id = ${id}
+`;
+```
+
+After formatting:
+
+```ts
+const animals = await sql`
+  SELECT
+    first_name,
+    species
+  FROM
+    animals
+  WHERE
+    id = ${id}
+`;
+```
+
 ## Parser Options
 
 ```ts

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -57,7 +57,7 @@ Format SQL-in-JS tagged template literals by installing [`prettier-plugin-embed`
 /** @type {import('prettier').Config} */
 const prettierConfig = {
   plugins: ['prettier-plugin-embed', 'prettier-plugin-sql'],
-};
+}
 
 /** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
 const prettierPluginEmbedConfig = {
@@ -74,9 +74,9 @@ const config = {
   ...prettierConfig,
   ...prettierPluginEmbedConfig,
   ...prettierPluginSqlConfig,
-};
+}
 
-export default config;
+export default config
 ```
 
 Before formatting:
@@ -87,7 +87,7 @@ const animals = await sql`
    animals
          WhERE
  id = ${id}
-`;
+`
 ```
 
 After formatting:
@@ -101,7 +101,7 @@ const animals = await sql`
     animals
   WHERE
     id = ${id}
-`;
+`
 ```
 
 ## Parser Options

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -49,11 +49,6 @@ yarn prettier --write db.sql
 
 ### SQL-in-JS with `prettier-plugin-embed`
 
-
-### Config Examples
-
-#### `prettier-plugin-sql` and `sql-formatter`
-
 Format SQL-in-JS tagged template literals by installing [`prettier-plugin-embed`](https://github.com/Sec-ant/prettier-plugin-embed) and configuring as follows:
 
 `prettier.config.mjs`


### PR DESCRIPTION
Closes #217

Alternative `.prettierrc` version of the config (downside: untyped):

```json
{
  "plugins": ["prettier-plugin-embed", "prettier-plugin-sql"],
  "embeddedSqlIdentifiers": ["sql"],
  "language": "postgresql",
  "keywordCase": "upper",
}
```