### PR TITLE
Update README.md to match package.json

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -13,7 +13,7 @@ Of course it should just work, but may not match [prettier][]'s format sometimes
 
 ## Requirements
 
-`prettier-plugin-sql` is an evergreen module. 🌲 This module requires an [LTS](https://github.com/nodejs/Release) Node version (v12.0.0+).
+`prettier-plugin-sql` is an evergreen module. 🌲 This module requires an [LTS](https://github.com/nodejs/Release) Node version (v14.18.0+).
 
 ## Install
 


### PR DESCRIPTION
See [package.json](https://github.com/un-ts/prettier/blob/f1c25563fcabb17bf51a949e43ecfc3d30d8951a/packages/sql/package.json#L12). 

We might also consider just saying `v16.0.0+` here so we don't have specify the specific minor version of `v14.18.0`? Thoughts? 