### PR TITLE
feat(sh): add pragma support

### DIFF
--- a/.changeset/sharp-days-kiss.md
+++ b/.changeset/sharp-days-kiss.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-sh': minor
+---
+
+add support for file pragmas

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -40,6 +40,10 @@
     "mvdan-sh": "^0.10.1",
     "sh-syntax": "^0.4.2"
   },
+  "devDependencies": {
+    "@types/common-tags": "^1.8.4",
+    "common-tags": "^1.8.2"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/sh/test/parser.spec.ts
+++ b/packages/sh/test/parser.spec.ts
@@ -1,0 +1,116 @@
+import { stripIndent } from 'common-tags'
+import { describe, it, assert, expect } from 'vitest'
+
+import ShPlugin from 'prettier-plugin-sh'
+
+describe('parser', () => {
+  const hasPragma = ShPlugin.parsers?.sh?.hasPragma
+  assert(hasPragma != null)
+
+  describe('should detect pragmas', () => {
+    it('at the top of the file', () => {
+      expect(
+        hasPragma(stripIndent`
+        # @prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('with extra leading spaces', () => {
+      expect(
+        hasPragma(stripIndent`
+        #   @prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('with no leading space', () => {
+      expect(
+        hasPragma(stripIndent`
+        #@prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('with "format" pragma instead', () => {
+      expect(
+        hasPragma(stripIndent`
+        # @format
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('after leading whitespace', () => {
+      expect(
+        hasPragma(stripIndent`
+
+
+        # @prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('after leading comments', () => {
+      expect(
+        hasPragma(stripIndent`
+        # Testing!
+
+        #
+        #
+        # @prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('after a shebang', () => {
+      expect(
+        hasPragma(stripIndent`
+        #!/bin/bash
+        #
+
+        # @prettier
+        FOO="bar"
+      `),
+      ).toBeTruthy()
+    })
+
+    it('unless none exist', () => {
+      expect(
+        hasPragma(stripIndent`
+        FOO="bar"
+      `),
+      ).toBeFalsy()
+    })
+
+    it('unless the file is empty', () => {
+      expect(hasPragma('')).toBeFalsy()
+    })
+
+    it('unless it comes after real content', () => {
+      expect(
+        hasPragma(stripIndent`
+        FOO="bar"
+        # @prettier
+      `),
+      ).toBeFalsy()
+    })
+
+    it('unless it comes after real content and comments', () => {
+      expect(
+        hasPragma(stripIndent`
+
+        # Test
+        #!
+        FOO="bar"
+        # @prettier
+      `),
+      ).toBeFalsy()
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,13 @@ importers:
       sh-syntax:
         specifier: ^0.4.2
         version: 0.4.2
+    devDependencies:
+      '@types/common-tags':
+        specifier: ^1.8.4
+        version: 1.8.4
+      common-tags:
+        specifier: ^1.8.2
+        version: 1.8.2
 
   packages/sql:
     dependencies:
@@ -4583,6 +4590,10 @@ packages:
     resolution: {integrity: sha512-uLK0/0dOYdkX8hNsezpYh1gc8eerbhf9bOKZ3e24sP67703mw9S14/yW6mSTatiaKO9v+mU/a1EVy4rOXXeZTA==}
     dev: true
 
+  /@types/common-tags@1.8.4:
+    resolution: {integrity: sha512-S+1hLDJPjWNDhcGxsxEbepzaxWqURP/o+3cP4aa2w7yBXgdcmKGQtZzP8JbyfOd0m+33nh+8+kvxYE2UJtBDkg==}
+    dev: true
+
   /@types/concat-stream@2.0.0:
     resolution: {integrity: sha512-t3YCerNM7NTVjLuICZo5gYAXYoDvpuuTceCcFQWcDQz26kxUR5uIWolxbIR5jRNIXpMqhOpW/b8imCR1LEmuJw==}
     dependencies:
@@ -6335,6 +6346,11 @@ packages:
   /comment-parser@1.3.1:
     resolution: {integrity: sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==}
     engines: {node: '>= 12.0.0'}
+    dev: true
+
+  /common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
     dev: true
 
   /commondir@1.0.1:


### PR DESCRIPTION
Closes #377

----

The approach I took differs from that described in the related ticket. As I started working and read Prettier's plugin API and implementation, I realized we don't have access to all of the options required to instantiate the parser until *after* the pragma check has happened. Without that, we couldn't cache or memoize and using the actual Parser would mean every file would need to be parsed twice.

So this takes a regex-based approach to just chomp off the top of a file until it comes across non-comment content, scanning for the pragma along the way.