### PR TITLE
fix(sh): exclude `ShellSession` language

### DIFF
--- a/.changeset/light-pots-remain.md
+++ b/.changeset/light-pots-remain.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-sh": minor
+---
+
+fix(sh): exclude `ShellSession` language

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@vitejs/plugin-react-swc": "^3.7.0",
     "@vitest/coverage-istanbul": "^1.0.4",
     "github-markdown-css": "^5.4.0",
-    "linguist-languages": "^7.27.0",
+    "linguist-languages": "^7.29.0",
     "lodash": "^4.17.21",
     "prettier": "^3.2.4",
     "prettier-plugin-autocorrect": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       linguist-languages:
-        specifier: ^7.27.0
-        version: 7.27.0
+        specifier: ^7.29.0
+        version: 7.29.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -10299,8 +10299,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /linguist-languages@7.27.0:
-    resolution: {integrity: sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw==}
+  /linguist-languages@7.29.0:
+    resolution: {integrity: sha512-KTh6ltVzr3ycnqxWw7zlzy8CqTSrpdymUzGl0EgYxK7cHoRgsX3VrZw4ExCWGCPX3uxxa7kgZwir4zeQkqjdZw==}
     dev: true
 
   /lint-staged@13.2.3:

--- a/scripts/languages.ts
+++ b/scripts/languages.ts
@@ -36,9 +36,10 @@ const EXTRA_SH_LANGUAGES: SupportLanguage[] = [
   },
 ]
 
-const getSupportLanguages = (
+const getSupportedLanguages = (
   parser: 'autocorrect' | 'sh' | 'sql' | 'toml',
   aceModes: string[],
+  excludeNames?: string[],
 ) =>
   Object.values(LinguistLanguages).reduce<SupportLanguage[]>(
     (
@@ -53,6 +54,9 @@ const getSupportLanguages = (
       },
     ) => {
       if (!aceModes.includes('all') && !aceModes.includes(aceMode)) {
+        return acc
+      }
+      if (excludeNames?.includes(name)) {
         return acc
       }
       acc.push({
@@ -74,7 +78,7 @@ fs.writeFileSync(
   `import { SupportLanguage } from 'prettier'
 
 export const languages = ${JSON.stringify(
-    getSupportLanguages('autocorrect', ['all']),
+    getSupportedLanguages('autocorrect', ['all']),
     null,
     2,
   )} as SupportLanguage[]`,
@@ -86,7 +90,15 @@ fs.writeFileSync(
 
 export const languages = ${JSON.stringify(
     [
-      ...getSupportLanguages('sh', ['dockerfile', 'gitignore', 'sh']),
+      ...getSupportedLanguages(
+        'sh',
+        ['dockerfile', 'gitignore', 'sh'],
+        [
+          // `ShellSession` includes both commands and output. We can't reliably
+          // format the latter, so we exclude this language entirely.
+          'ShellSession',
+        ],
+      ),
       ...EXTRA_SH_LANGUAGES,
     ],
     null,
@@ -99,7 +111,7 @@ fs.writeFileSync(
   `import { SupportLanguage } from 'prettier'
 
 export const languages = ${JSON.stringify(
-    [...getSupportLanguages('sql', ['sql', 'pgsql'])],
+    [...getSupportedLanguages('sql', ['sql', 'pgsql'])],
     null,
     2,
   )} as SupportLanguage[]`,
@@ -110,7 +122,7 @@ fs.writeFileSync(
   `import { SupportLanguage } from 'prettier'
 
 export const languages = ${JSON.stringify(
-    [...getSupportLanguages('toml', ['toml'])],
+    [...getSupportedLanguages('toml', ['toml'])],
     null,
     2,
   )} as SupportLanguage[]`,


### PR DESCRIPTION
Closes #415.

Per the request from https://github.com/un-ts/prettier/issues/415#issuecomment-2762094779, I also updated `linguist-languages`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved language customization now offers enhanced filtering options to tailor which languages are displayed.
  
- **Chores**
  - Upgraded the `linguist-languages` dependency to the latest version for potential bug fixes and improvements.
  - Added a new entry for the exclusion of the `ShellSession` language in the `prettier-plugin-sh`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->