### PR TITLE
docs: add `TOML` parser options to README

### DIFF
--- a/.changeset/forty-wasps-jam.md
+++ b/.changeset/forty-wasps-jam.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-toml": patch
+---
+
+docs: add `TOML` parser options to README

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -50,7 +50,7 @@ yarn prettier --write foo.toml
 ## Parse Options
 
 ```ts
-interface prettierOptions {
+interface PrettierOptions {
   // 'Align consecutive entries vertically.'
   alignEntries: boolean // default `false`
   // Align consecutive comments after entries and items vertically. This applies

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -53,11 +53,13 @@ yarn prettier --write foo.toml
 interface prettierOptions {
   // 'Align consecutive entries vertically.'
   alignEntries: boolean // default `false`
-  // Align consecutive comments after entries and items vertically. This applies to comments that are after entries or array items.
+  // Align consecutive comments after entries and items vertically. This applies
+  // to comments that are after entries or array items.
   alignComments: boolean // default `true`
   // Expand arrays to multiple lines that exceed the maximum column width.
   arrayAutoExpand: boolean // default `true`
-  // Collapse arrays that don't exceed the maximum column width and don't contain comments.
+  // Collapse arrays that don't exceed the maximum column width and don't
+  // contain comments.
   arrayAutoCollapse: boolean // default `true`
   // Omit white space padding from single-line arrays.
   compactArrays: boolean // default `true`
@@ -65,7 +67,8 @@ interface prettierOptions {
   compactInlineTables:  boolean // default `false`
   // Omit white space around `=`.
   compactEntries: boolean // default `false`
-  // Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+  // Indent based on tables and arrays of tables and their subtables, subtables
+  // out of order are not indented.
   indentTables: boolean // default `false`
   // Indent entries under tables.
   indentEntries: boolean // default `false`

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -47,7 +47,7 @@ npx prettier --write foo.toml
 yarn prettier --write foo.toml
 ```
 
-## Parsre Options
+## Parse Options
 
 ```ts
 interface prettierOptions {

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -47,7 +47,7 @@ npx prettier --write foo.toml
 yarn prettier --write foo.toml
 ```
 
-## Parse Options
+## Parser Options
 
 ```ts
 interface PrettierOptions {

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -75,7 +75,7 @@ interface PrettierOptions {
   // Alphabetically reorder keys that are not separated by empty lines.
   reorderKeys: boolean // default `false`
   // The maximum number of allowed blank lines between entries and tables.
-  allowedBlankLines: int // default `1`
+  allowedBlankLines: number // integer, default `1`
 }
 ```
 

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -64,7 +64,7 @@ interface PrettierOptions {
   // Omit white space padding from single-line arrays.
   compactArrays: boolean // default `true`
   // Omit white space padding from the start and end of inline tables.
-  compactInlineTables:  boolean // default `false`
+  compactInlineTables: boolean // default `false`
   // Omit white space around `=`.
   compactEntries: boolean // default `false`
   // Indent based on tables and arrays of tables and their subtables, subtables

--- a/packages/toml/README.md
+++ b/packages/toml/README.md
@@ -47,6 +47,35 @@ npx prettier --write foo.toml
 yarn prettier --write foo.toml
 ```
 
+## Parsre Options
+
+```ts
+interface prettierOptions {
+  // 'Align consecutive entries vertically.'
+  alignEntries: boolean // default `false`
+  // Align consecutive comments after entries and items vertically. This applies to comments that are after entries or array items.
+  alignComments: boolean // default `true`
+  // Expand arrays to multiple lines that exceed the maximum column width.
+  arrayAutoExpand: boolean // default `true`
+  // Collapse arrays that don't exceed the maximum column width and don't contain comments.
+  arrayAutoCollapse: boolean // default `true`
+  // Omit white space padding from single-line arrays.
+  compactArrays: boolean // default `true`
+  // Omit white space padding from the start and end of inline tables.
+  compactInlineTables:  boolean // default `false`
+  // Omit white space around `=`.
+  compactEntries: boolean // default `false`
+  // Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+  indentTables: boolean // default `false`
+  // Indent entries under tables.
+  indentEntries: boolean // default `false`
+  // Alphabetically reorder keys that are not separated by empty lines.
+  reorderKeys: boolean // default `false`
+  // The maximum number of allowed blank lines between entries and tables.
+  allowedBlankLines: int // default `1`
+}
+```
+
 ## Sponsors
 
 | 1stG                                                                                                                               | RxTS                                                                                                                               | UnTS                                                                                                                               |


### PR DESCRIPTION
I was curious what options were available and couldn't easily finding it without digging into the source. I went looking at other plugins and there doesn't seem to be a consistent pattern, with some writing `json` and others choosing a `<table></table>`. I looked at the other packages in the repo, and you use a code fence. I followed that convention.

Hope you don't mind the PR, hopefully it will be easier for others to know what options are supported.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section titled "Parser Options" detailing configuration settings for TOML file formatting options, including the `PrettierOptions` interface and its properties for customizing formatting behavior with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->