### PR TITLE
chore: bump `@reteps/dockerfmt`, fix related ESM only usage

### DIFF
--- a/.changeset/eighty-snails-rescue.md
+++ b/.changeset/eighty-snails-rescue.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-sh": patch
+---
+
+chore: bump `@reteps/dockerfmt`, fix related ESM only usage

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -50,7 +50,7 @@
     "prettier": "^3.0.3"
   },
   "dependencies": {
-    "@reteps/dockerfmt": "^0.2.3",
+    "@reteps/dockerfmt": "^0.2.5",
     "sh-syntax": "^0.5.6"
   },
   "devDependencies": {

--- a/packages/sh/src/index.ts
+++ b/packages/sh/src/index.ts
@@ -1,4 +1,3 @@
-import { formatDockerfileContents } from '@reteps/dockerfmt'
 import type { Parser, ParserOptions, Plugin, Printer } from 'prettier'
 import {
   type File,
@@ -94,6 +93,18 @@ const dockerfileParser: Parser<string> = {
   locEnd: node => node.length,
 }
 
+let formatDockerfileContents_:
+  | typeof import('@reteps/dockerfmt').formatDockerfileContents
+  | undefined
+
+const getFormatDockerfileContents = async () => {
+  if (!formatDockerfileContents_) {
+    const dockerfmt = await import('@reteps/dockerfmt')
+    formatDockerfileContents_ = dockerfmt.formatDockerfileContents
+  }
+  return formatDockerfileContents_
+}
+
 const dockerPrinter: Printer<string> = {
   // @ts-expect-error -- https://github.com/prettier/prettier/issues/15080#issuecomment-1630987744
   async print(
@@ -108,6 +119,7 @@ const dockerPrinter: Printer<string> = {
     if (!node) {
       return ''
     }
+    const formatDockerfileContents = await getFormatDockerfileContents()
     return formatDockerfileContents(node, {
       indent,
       trailingNewline: true,
@@ -204,6 +216,7 @@ const shPrinter: Printer<Node | string> = {
     }
 
     try {
+      const formatDockerfileContents = await getFormatDockerfileContents()
       return await formatDockerfileContents(node, {
         indent,
         trailingNewline: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4015,12 +4015,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reteps/dockerfmt@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "@reteps/dockerfmt@npm:0.2.3"
+"@reteps/dockerfmt@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@reteps/dockerfmt@npm:0.2.5"
   dependencies:
     typescript: "npm:^5.8.3"
-  checksum: 10c0/040bfbf13b31b749dae42cb7c8baf41d650cceb6b36ab029d3da291b52558bd2fc1dc39adc2d6b4390364797c00f5dd2875499df3b3ce86f9c858676b15a8ce3
+  checksum: 10c0/632545c00b9f4dae9d2ecea82a73356f744f7cb94d4a35f8721b7bd858b996bc88da3e3c7e864287aa909b1b70b45442b1cc94933ee46f8e39127f775f4eba8c
   languageName: node
   linkType: hard
 
@@ -14029,7 +14029,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "prettier-plugin-sh@workspace:packages/sh"
   dependencies:
-    "@reteps/dockerfmt": "npm:^0.2.3"
+    "@reteps/dockerfmt": "npm:^0.2.5"
     "@types/common-tags": "npm:^1.8.4"
     common-tags: "npm:^1.8.2"
     sh-syntax: "npm:^0.5.6"


### PR DESCRIPTION
close #434
close https://github.com/reteps/dockerfmt/pull/7

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the `@reteps/dockerfmt` dependency to version `^0.2.5`, introducing potential bug fixes and enhancements.
- **New Features**
	- Introduced a lazy-loading mechanism for the formatting function to improve initial load performance in the printing processes.
	- Added a new asynchronous function for dynamic import of the formatting function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->