### PR TITLE
fix: remove buggy `module-sync` exports field

### DIFF
--- a/.changeset/little-baboons-ring.md
+++ b/.changeset/little-baboons-ring.md
@@ -1,0 +1,9 @@
+---
+"prettier-plugin-autocorrect": patch
+"prettier-plugin-pkg": patch
+"prettier-plugin-sh": patch
+"prettier-plugin-sql": patch
+"prettier-plugin-toml": patch
+---
+
+fix: remove buggy `module-sync` exports field

--- a/packages/autocorrect/package.json
+++ b/packages/autocorrect/package.json
@@ -19,10 +19,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "module-sync": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
-    },
     "require": {
       "types": "./index.d.cts",
       "default": "./lib/index.cjs"

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -19,10 +19,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "module-sync": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
-    },
     "require": {
       "types": "./index.d.cts",
       "default": "./lib/index.cjs"

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -19,10 +19,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "module-sync": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
-    },
     "require": {
       "types": "./index.d.cts",
       "default": "./lib/index.cjs"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -19,10 +19,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "module-sync": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
-    },
     "require": {
       "types": "./index.d.cts",
       "default": "./lib/index.cjs"

--- a/packages/toml/package.json
+++ b/packages/toml/package.json
@@ -22,10 +22,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "module-sync": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
-    },
     "require": {
       "types": "./index.d.cts",
       "default": "./lib/index.cjs"


### PR DESCRIPTION
This is the only difference I can tell between `prettier-plugin-toml` v2.0.3 vs v2.0.4

close #452

related https://github.com/un-ts/pkgr/issues/391

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `module-sync` export field from `package.json` in multiple packages.
> 
>   - **Exports Field Removal**:
>     - Removed `module-sync` export field from `package.json` in `autocorrect`, `pkg`, `sh`, `sql`, and `toml` packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fprettier&utm_source=github&utm_medium=referral)<sup> for 0de2845554032a1d08d9367eca9c2e9bcfc360bc. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the problematic "module-sync" export entry from several packages to resolve related issues. This affects autocorrect, pkg, sh, sql, and toml plugins.
- **Chores**
	- Updated package configuration for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->