### PR TITLE
fix(sh): fallback to `sh` printer when `dockerfmt` throws

### DIFF
--- a/.changeset/rotten-dancers-bow.md
+++ b/.changeset/rotten-dancers-bow.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-sh": patch
+---
+
+fix: fallback to `sh` printer when `dockerfmt` throws

--- a/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
+++ b/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
@@ -890,6 +890,17 @@ exports[`parser and printer > should format 441.Dockerfile fixture correctly wit
 "
 `;
 
+exports[`parser and printer > should format 445.Dockerfile fixture correctly 1`] = `
+"FROM nginx
+WORKDIR /app
+ARG PROJECT_DIR=/
+ARG NGINX_CONF=nginx.conf
+COPY $NGINX_CONF /etc/nginx/conf.d/nginx.conf
+COPY $PROJECT_DIR /app
+CMD mkdir --parents /var/log/nginx && nginx -g "daemon off;"
+"
+`;
+
 exports[`parser and printer > should format 445.sh fixture correctly 1`] = `"reached EOF without closing quote '"`;
 
 exports[`parser and printer > should format Dockerfile fixture correctly 1`] = `

--- a/packages/sh/test/fixtures/445.Dockerfile
+++ b/packages/sh/test/fixtures/445.Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx
+WORKDIR /app
+ARG PROJECT_DIR=/
+ARG NGINX_CONF=nginx.conf
+COPY $NGINX_CONF /etc/nginx/conf.d/nginx.conf
+COPY $PROJECT_DIR /app
+CMD mkdir --parents /var/log/nginx && nginx -g "daemon off;"


### PR DESCRIPTION
close #441

close #445
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add fallback to `sh` printer in `dockerPrinter` when `dockerfmt` throws, with new test case for verification.
> 
>   - **Behavior**:
>     - In `dockerPrinter.print()` in `index.ts`, add fallback to `sh` printer when `dockerfmt` throws an error.
>     - Handles unexpected errors from `dockerfmt` by using `sh` printer with the same options.
>   - **Testing**:
>     - Add test case for `445.Dockerfile` in `fixtures.spec.ts.snap` to verify fallback behavior.
>     - New fixture `445.Dockerfile` added for testing in `test/fixtures`.
>   - **Misc**:
>     - Update `ShPrintOptions` in `index.ts` to include additional printer options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fprettier&utm_source=github&utm_medium=referral)<sup> for 1ea670090e9f693e01fe57e40814cbfe89bb2308. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Dockerfile formatting to ensure formatting continues even if the Dockerfile formatter encounters issues, by automatically falling back to an alternative formatter.

- **Tests**
  - Added a new Dockerfile test case to verify formatting and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->