### PR TITLE
feat(pkg): add `libc` and `devEngines` support

### DIFF
--- a/.changeset/fuzzy-crabs-impress.md
+++ b/.changeset/fuzzy-crabs-impress.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-pkg": minor
+---
+
+feat(pkg): add `libc` and `devEngines` support

--- a/packages/pkg/README.md
+++ b/packages/pkg/README.md
@@ -97,6 +97,8 @@ Top-level keys are sorted according to a style commonly seen in the packages of 
   "engines",
   "cpu",
   "os",
+  "libc",
+  "devEngines",
 
   // entries
   "man",

--- a/packages/pkg/src/index.ts
+++ b/packages/pkg/src/index.ts
@@ -22,7 +22,7 @@ const {
 } = babelParser.parsers
 
 const format = (properties: ObjectProperty[]) => {
-  let props = ['engines', 'scripts', ...dependencyNames].reduce(
+  let props = ['engines', 'devEngines', 'scripts', ...dependencyNames].reduce(
     (acc, item) => object(acc, item),
     sort(properties),
   )

--- a/packages/pkg/src/rules/sort.ts
+++ b/packages/pkg/src/rules/sort.ts
@@ -60,6 +60,8 @@ const primary = [
   'engines',
   'cpu',
   'os',
+  'libc',
+  'devEngines',
 
   // entries
   'man',


### PR DESCRIPTION
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#libc
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines

close #440

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `libc` and `devEngines` keys in `prettier-plugin-pkg`, updating sorting logic and documentation.
> 
>   - **Behavior**:
>     - Adds support for `libc` and `devEngines` keys in `packages/pkg/src/index.ts` and `packages/pkg/src/rules/sort.ts`.
>     - Updates sorting logic in `format()` in `index.ts` to include `devEngines`.
>   - **Documentation**:
>     - Updates `README.md` to include `libc` and `devEngines` in the top-level keys list.
>   - **Misc**:
>     - Adds changeset file `fuzzy-crabs-impress.md` to document the feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fprettier&utm_source=github&utm_medium=referral)<sup> for 402d6f824bfeb238c89580f5b2a2c80b19ffcee0. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->