### PR TITLE
feat(pkg): add option packageIgnoreSort

### DIFF
--- a/.changeset/full-frogs-join.md
+++ b/.changeset/full-frogs-join.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-pkg": minor
+---
+
+feat(pkg): add option `packageIgnoreSort`

--- a/packages/pkg/src/index.ts
+++ b/packages/pkg/src/index.ts
@@ -25,10 +25,15 @@ const {
   json: { parse },
 } = babelParser.parsers
 
+const DEFAULT_SORTS = ['engines', 'devEngines', 'scripts', ...dependencyNames]
+
 const format = (properties: ObjectProperty[], options: FormatOptions) => {
-  let props = ['engines', 'devEngines', 'scripts', ...dependencyNames]
-    .filter(item => !options.packageIgnoreSort?.includes(item))
-    .reduce((acc, item) => object(acc, item), sort(properties, options))
+  const { packageIgnoreSort } = options
+  let props = (
+    packageIgnoreSort?.length
+      ? DEFAULT_SORTS.filter(item => !packageIgnoreSort.includes(item))
+      : DEFAULT_SORTS
+  ).reduce((acc, item) => object(acc, item), sort(properties, options))
   props = files(props)
   return props
 }

--- a/packages/pkg/src/index.ts
+++ b/packages/pkg/src/index.ts
@@ -14,9 +14,9 @@ import { files } from './rules/files.js'
 import { object } from './rules/object.js'
 import { dependencyNames, sort } from './rules/sort.js'
 import type {
+  FormatOptions,
   ObjectExpression,
   ObjectProperty,
-  FormatOptions,
 } from './types.js'
 
 const PKG_REG = /[/\\]?package\.json$/
@@ -26,10 +26,9 @@ const {
 } = babelParser.parsers
 
 const format = (properties: ObjectProperty[], options: FormatOptions) => {
-  let props = ['engines', 'devEngines', 'scripts', ...dependencyNames].reduce(
-    (acc, item) => object(acc, item, options),
-    sort(properties, options),
-  )
+  let props = ['engines', 'devEngines', 'scripts', ...dependencyNames]
+    .filter(item => !options.packageIgnoreSort?.includes(item))
+    .reduce((acc, item) => object(acc, item), sort(properties, options))
   props = files(props)
   return props
 }

--- a/packages/pkg/src/index.ts
+++ b/packages/pkg/src/index.ts
@@ -27,7 +27,7 @@ const {
 
 const format = (properties: ObjectProperty[], options: FormatOptions) => {
   let props = ['engines', 'devEngines', 'scripts', ...dependencyNames].reduce(
-    (acc, item) => object(acc, item),
+    (acc, item) => object(acc, item, options),
     sort(properties, options),
   )
   props = files(props)
@@ -61,6 +61,15 @@ export default {
       default: [{ value: [] }],
       description:
         'An array of property names to sort the package.json properties by.',
+    },
+    packageIgnoreSort: {
+      since: '0.21.0',
+      category: 'Package',
+      type: 'string',
+      array: true,
+      default: [{ value: [] }],
+      description:
+        'An array of property names to ignore when sorting the package.json properties.',
     },
   },
 } as Plugin

--- a/packages/pkg/src/rules/object.ts
+++ b/packages/pkg/src/rules/object.ts
@@ -7,18 +7,10 @@
  * Code Form.
  */
 
-import type { FormatOptions, ObjectProperty, StringLiteral } from '../types.js'
+import type { ObjectProperty, StringLiteral } from '../types.js'
 import { sortObject, sortStringArray } from '../utils.js'
 
-const process = (
-  props: ObjectProperty[],
-  key: string,
-  options: FormatOptions,
-) => {
-  if (options.packageIgnoreSort?.includes(key)) {
-    return props
-  }
-
+const process = (props: ObjectProperty[], key: string) => {
   const item = props.find(prop => prop.key.value === key)
 
   if (item) {

--- a/packages/pkg/src/rules/object.ts
+++ b/packages/pkg/src/rules/object.ts
@@ -7,10 +7,18 @@
  * Code Form.
  */
 
-import type { ObjectProperty, StringLiteral } from '../types.js'
+import type { FormatOptions, ObjectProperty, StringLiteral } from '../types.js'
 import { sortObject, sortStringArray } from '../utils.js'
 
-const process = (props: ObjectProperty[], key: string) => {
+const process = (
+  props: ObjectProperty[],
+  key: string,
+  options: FormatOptions,
+) => {
+  if (options.packageIgnoreSort?.includes(key)) {
+    return props
+  }
+
   const item = props.find(prop => prop.key.value === key)
 
   if (item) {

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -46,4 +46,5 @@ export type { StringLiteral } from '@babel/types'
 
 export interface FormatOptions {
   packageSortOrder?: string[]
+  packageIgnoreSort?: string[]
 }

--- a/packages/pkg/test/__snapshots__/ignore-sort.spec.ts.snap
+++ b/packages/pkg/test/__snapshots__/ignore-sort.spec.ts.snap
@@ -1,0 +1,53 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ignore-sort 1`] = `
+"{
+  "name": "prettier-plugin-pkg",
+  "version": "0.0.0",
+  "description": "An opinionated package.json formatter plugin for Prettier",
+  "repository": "git@github.com/un-ts/prettier.git",
+  "homepage": "https://github.com/un-ts/prettier/tree/master/packages/pkg",
+  "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
+  "license": "MPL-2.0",
+  "engines": {
+    "node": ">= 8.0.0"
+  },
+  "main": "lib/cjs",
+  "module": "lib/esm",
+  "es2015": "lib/es2015",
+  "files": [
+    "lib",
+    "rules"
+  ],
+  "keywords": [
+    "package",
+    "package.json",
+    "pkg",
+    "plugin",
+    "prettier",
+    "prettier-plugin"
+  ],
+  "peerDependencies": {
+    "prettier": "^1.18.2"
+  },
+  "resolutions": {
+    "imagemin-gifsicle": "^6.0.1",
+    "@babel/core": "^7.9.0",
+    "typescript": "^3.8.3",
+    "prettier": "^2.0.4",
+    "@babel/preset-env": "^7.12.1",
+    "eslint-plugin-prettier": "^3.1.2"
+  },
+  "commitlint": {
+    "extends": [
+      "@1stg"
+    ]
+  },
+  "eslintIgnore": [
+    "CHANGELOG.md",
+    "lib",
+    "!.*.js"
+  ]
+}
+"
+`;

--- a/packages/pkg/test/ignore-sort.spec.ts
+++ b/packages/pkg/test/ignore-sort.spec.ts
@@ -1,0 +1,17 @@
+import { format } from 'prettier'
+
+import pkg1 from './fixtures/fixture1.json'
+
+import PkgPlugin from 'prettier-plugin-pkg'
+
+test('ignore-sort', async () => {
+  const input = JSON.stringify(pkg1, null, 2)
+  const output = await format(input, {
+    filepath: 'package.json',
+    parser: 'json-stringify',
+    plugins: [PkgPlugin],
+    packageIgnoreSort: ['resolutions'],
+  })
+
+  expect(output).toMatchSnapshot()
+})


### PR DESCRIPTION
closes #466 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `packageIgnoreSort` option to `prettier-plugin-pkg` to ignore sorting specified `package.json` properties.
> 
>   - **Feature**:
>     - Add `packageIgnoreSort` option in `index.ts` to specify properties in `package.json` to ignore during sorting.
>     - Update `process()` in `object.ts` to skip sorting for keys in `packageIgnoreSort`.
>   - **Types**:
>     - Add `packageIgnoreSort` to `FormatOptions` in `types.ts`.
>   - **Tests**:
>     - Add `ignore-sort.spec.ts` to test `packageIgnoreSort` functionality with a snapshot test.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fprettier&utm_source=github&utm_medium=referral)<sup> for fb938a5bb2c5e1059ff1ea4cc46d772ada8e8913. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to ignore sorting for specified properties in package.json files.
- **Tests**
  - Introduced tests to verify that ignored properties are not sorted when the new option is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->