### PR TITLE
docs(pkg): add document about the new format options

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   size-limit:
+    if: ${{ github.repository_owner == 'un-ts' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.repository_owner == 'un-ts' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,15 +1,15 @@
 [
   {
     "path": "packages/autocorrect/lib/index.js",
-    "limit": "540B"
-  },
-  {
-    "path": "packages/pkg/lib/index.js",
     "limit": "500B"
   },
   {
+    "path": "packages/pkg/lib/index.js",
+    "limit": "600B"
+  },
+  {
     "path": "packages/sh/lib/index.js",
-    "limit": "3.4kB"
+    "limit": "3kB"
   },
   {
     "path": "packages/sql/lib/index.js",

--- a/packages/pkg/README.md
+++ b/packages/pkg/README.md
@@ -168,6 +168,17 @@ Forthcoming rules include:
 - [ ] Author format
 - [ ] Repository format
 
+## Format Options
+
+```ts
+interface FormatOptions {
+  // An array of property names to sort the package.json properties by.
+  packageSortOrder?: string[]
+  // An array of property names to ignore when sorting the package.json properties.
+  packageIgnoreSort?: string[]
+}
+```
+
 ## Acknowledgements
 
 Thanks for [@shellscape](https://github.com/shellscape)'s original great work of [prettier-plugin-package][] again.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Added format options documentation and updated workflow conditions and size limits.
> 
>   - **Documentation**:
>     - Added "Format Options" section in `README.md` for package formatting configuration.
>   - **Configuration**:
>     - Updated `.size-limit.json` to adjust size limits for `autocorrect`, `pkg`, and `sh` packages.
>     - Added condition in `size-limit.yml` and `vercel.yml` workflows to run jobs only if repository owner is `un-ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fprettier&utm_source=github&utm_medium=referral)<sup> for 2971f6eef9fda03cb4f7ca9323b085ac2f277b96. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new "Format Options" section to the documentation, describing available configuration options for package formatting.

- **Chores**
  - Adjusted size limits for specific package files to reflect new thresholds.
  - Updated workflow configurations to restrict certain jobs to run only for the repository owner "un-ts".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->