### PR TITLE
chore: bump `@reteps/dockerfmt` to v0.5.1

### DIFF
--- a/.changeset/bump-dockerfmt.md
+++ b/.changeset/bump-dockerfmt.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-sh": patch
+---
+
+chore: bump `@reteps/dockerfmt` to v0.5.1

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -46,7 +46,7 @@
     "prettier": "^3.6.0"
   },
   "dependencies": {
-    "@reteps/dockerfmt": "^0.3.6",
+    "@reteps/dockerfmt": "^0.5.1",
     "sh-syntax": "^0.5.8"
   },
   "devDependencies": {

--- a/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
+++ b/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
@@ -868,9 +868,9 @@ RUN set -eux; for x in {1..3}; do echo 'foo'; echo 'bar'; echo "$x"; done
 RUN <<EOF
 set -eux
 for x in {1..3}; do
- echo 'foo'
- echo 'bar'
- echo "$x"
+  echo 'foo'
+  echo 'bar'
+  echo "$x"
 done
 EOF
 "
@@ -883,21 +883,21 @@ exports[`parser and printer > should format 384.Dockerfile fixture correctly 1`]
 
 exports[`parser and printer > should format 398.Dockerfile fixture correctly 1`] = `
 "ENV a=1 \\
- b=2 \\
- # comment
- c=3 \\
- d=4 \\
- # comment
- e=5
+  b=2 \\
+  # comment
+  c=3 \\
+  d=4 \\
+  # comment
+  e=5
 "
 `;
 
 exports[`parser and printer > should format 441.Dockerfile fixture correctly with options: {"indent":4} 1`] = `
 "RUN \\
- # install dependencies
- NODE_ENV=production npm install-clean \\
- # cleanup
- && /usr/bin/env bash <(curl -fsSL https://raw.githubusercontent.com/softvisio/scripts/main/env-build-node.sh) cleanup
+    # install dependencies
+    NODE_ENV=production npm install-clean \\
+    # cleanup
+    && /usr/bin/env bash <(curl -fsSL https://raw.githubusercontent.com/softvisio/scripts/main/env-build-node.sh) cleanup
 "
 `;
 
@@ -921,8 +921,8 @@ exports[`parser and printer > should format Dockerfile fixture correctly 1`] = `
 COPY . /app
 WORKDIR /app
 RUN yarn --frozen-lockfile \\
- && yarn build \\
- && find . -name '*.map' -type f -exec rm -f {} \\;
+  && yarn build \\
+  && find . -name '*.map' -type f -exec rm -f {} \\;
 
 # 最终的应用
 FROM abiosoft/caddy

--- a/yarn.lock
+++ b/yarn.lock
@@ -3778,10 +3778,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reteps/dockerfmt@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@reteps/dockerfmt@npm:0.3.6"
-  checksum: 10c0/b6ca467ba97ea49071c44d0fbecf131fc8045165e950d0d01372c1834000c58d53f62bff42f09b851f7a9d91899047f071cd8fe57e1fc88fc27e2a3d2bdb214d
+"@reteps/dockerfmt@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@reteps/dockerfmt@npm:0.5.1"
+  checksum: 10c0/161295c4d307b3bb54c6fa49ab2d53be082fc3303fdbb14e250d5b057cf79beba3c607e6db2df3cbf8b0391c4ba094f8afe4fac7223f3d2688ba22ea108fcb87
   languageName: node
   linkType: hard
 
@@ -13256,7 +13256,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "prettier-plugin-sh@workspace:packages/sh"
   dependencies:
-    "@reteps/dockerfmt": "npm:^0.3.6"
+    "@reteps/dockerfmt": "npm:^0.5.1"
     "@types/common-tags": "npm:^1.8.4"
     common-tags: "npm:^1.8.2"
     sh-syntax: "npm:^0.5.8"


### PR DESCRIPTION
Bumps `@reteps/dockerfmt` from `^0.3.6` to `^0.5.1`.

`0.5.0` fixes the dockerfmt bindings to work, and `0.5.1` avoids clobbering the Go runtime.

Also includes improved Dockerfile formatting — continuation lines now properly respect the configured `indent` option.

Hopefully, this closes #506 and closes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dockerfmt dependency to v0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->