### PR TITLE
feat(prettier-plugin-sh): ✨ support zsh dialect via sh-syntax@^0.6.0

### DIFF
--- a/.changeset/gh-511-add-zsh-support.md
+++ b/.changeset/gh-511-add-zsh-support.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-sh": minor
+---
+
+feat: ✨ support `zsh` dialect by upgrading `sh-syntax` to `^0.6.0`

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@reteps/dockerfmt": "^0.5.2",
-    "sh-syntax": "^0.5.8"
+    "sh-syntax": "^0.6.0"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.4",

--- a/packages/sh/src/index.ts
+++ b/packages/sh/src/index.ts
@@ -314,6 +314,15 @@ export const options: Plugin['options'] = {
         ].join('\n'),
       },
       {
+        value: LangVariant.LangZsh,
+        description: [
+          'LangZsh corresponds to the Z shell language, as described at https://www.zsh.org.',
+          'Note that it shares most features with Bash, adding zsh-specific extensions such as parameter modifier chains (e.g. "${0:A:h}").',
+          '',
+          'Its string representation is "zsh".',
+        ].join('\n'),
+      },
+      {
         value: LangVariant.LangAuto,
         description: [
           "LangAuto corresponds to automatic language detection, commonly used by end-user applications like shfmt, which can guess a file's language variant given its filename or shebang.",

--- a/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
+++ b/packages/sh/test/__snapshots__/fixtures.spec.ts.snap
@@ -912,7 +912,7 @@ CMD mkdir --parents /var/log/nginx && nginx -g "daemon off;"
 "
 `;
 
-exports[`parser and printer > should format 445.sh fixture correctly 1`] = `"reached EOF without closing quote '"`;
+exports[`parser and printer > should format 445.sh fixture correctly 1`] = `"reached EOF without closing quote \`'\`"`;
 
 exports[`parser and printer > should format Dockerfile fixture correctly 1`] = `
 "FROM node:lts-alpine as builder

--- a/packages/sh/test/error.spec.ts
+++ b/packages/sh/test/error.spec.ts
@@ -13,6 +13,6 @@ test('fatal parse error with meaningful message', async () => {
   )
   await rejects.toThrow(ParseError)
   await rejects.toThrow(
-    'a command can only contain words and redirects; encountered )',
+    'a command can only contain words and redirects; encountered `)`',
   )
 })

--- a/packages/sh/test/zsh.spec.ts
+++ b/packages/sh/test/zsh.spec.ts
@@ -1,0 +1,37 @@
+import { format } from 'prettier'
+import { LangVariant } from 'sh-syntax'
+import { describe, expect, it } from 'vitest'
+
+import * as sh from 'prettier-plugin-sh'
+
+/*
+ * Regression test for zsh support, tracking:
+ *   - sh-syntax issue:  https://github.com/un-ts/sh-syntax/issues/135
+ *   - sh-syntax fix PR: https://github.com/un-ts/sh-syntax/pull/136
+ *
+ * `${0:A:h:h}` is valid zsh (modifier chain: :A absolute path, :h head/dirname)
+ * but is rejected by the bash grammar with "ternary operator missing ? before :".
+ * sh-syntax >= 0.6.0 rebuilds the WASM against mvdan/sh v3.13 and exposes a
+ * dedicated `LangZsh` variant that parses it correctly.
+ *
+ * Expected results by installed sh-syntax version:
+ *   - 0.5.8 (before): RED - `LangZsh` is undefined and format() throws.
+ *   - 0.6.0 (after):  GREEN - the zsh variant parses and prints the input.
+ */
+describe('zsh support (sh-syntax >= 0.6.0)', () => {
+  const ZSH_SOURCE = 'DIR=${0:A:h:h}\n'
+
+  it('exposes the LangZsh variant constant', () => {
+    expect(LangVariant.LangZsh).toBeDefined()
+  })
+
+  it('formats a zsh modifier chain when using the zsh variant', async () => {
+    const output = await format(ZSH_SOURCE, {
+      filepath: 'script.zsh',
+      plugins: [sh],
+      variant: LangVariant.LangZsh,
+    })
+
+    expect(output).toContain('${0:A:h:h}')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -12730,7 +12730,7 @@ __metadata:
     "@reteps/dockerfmt": "npm:^0.5.2"
     "@types/common-tags": "npm:^1.8.4"
     common-tags: "npm:^1.8.2"
-    sh-syntax: "npm:^0.5.8"
+    sh-syntax: "npm:^0.6.0"
   peerDependencies:
     prettier: ^3.6.0
   languageName: unknown
@@ -14569,12 +14569,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sh-syntax@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "sh-syntax@npm:0.5.8"
-  dependencies:
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/2d2609fc8760ef97175c852be26ee3eeb196078c5aec282c8b96a59ee362be4f470d3e0df4e372da6c7a7b44ccc42910cbdcb0915271b3cb6a6212d00dde116f
+"sh-syntax@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "sh-syntax@npm:0.6.0"
+  checksum: 10c0/495c660a23c67725cdee077b423ca974521ae580302ee62eda9309c84f6cf31722560cdf55bbea5ca98ba7dd7ac352d59f3eed61612d42b1f8a41cfc7673ba9f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> **🤖 Disclaimer**: I had Claude help me generate this description.

## 🎯 Summary

- Adds **zsh dialect support** to `prettier-plugin-sh` by upgrading `sh-syntax` to `^0.6.0`.
- Valid zsh such as `${0:A:h:h}` (parameter modifier chains) previously failed with `ternary operator missing ? before :`; it now formats correctly under the new `zsh` variant.
- Closes #511.

## 🔗 Upstream

- Depends on `sh-syntax@0.6.0`, which rebuilds the WASM against `mvdan/sh` v3.13.1 and exposes a `LangZsh` variant.
- sh-syntax issue: https://github.com/un-ts/sh-syntax/issues/135
- sh-syntax fix PR: https://github.com/un-ts/sh-syntax/pull/136

## 🛠️ Changes

- **Dependency:** bump `sh-syntax` `^0.5.8` → `^0.6.0` (`packages/sh/package.json`, `yarn.lock`).
- **Option:** add `LangVariant.LangZsh` to the `variant` option `choices` in `packages/sh/src/index.ts`.
  - Without it, Prettier rejects the value with `Invalid variant value. Expected 1, 2, 4, 8 or 32, but received 16.`
- **Test:** add `packages/sh/test/zsh.spec.ts` covering the `LangZsh` constant and formatting of a zsh modifier chain.
- **Tests (upstream wording):** `mvdan/sh` v3.13 now backtick-quotes tokens in parse errors, so:
  - `test/error.spec.ts`: `encountered )` → `` encountered `)` ``
  - `test/__snapshots__/fixtures.spec.ts.snap` (`445.sh`): `closing quote '` → `` closing quote `'` ``
- **Changeset:** `minor` bump for `prettier-plugin-sh`.

## ✅ Verification

- `yarn build` ✅
- `yarn lint:es` ✅
- `yarn lint:tsc` ✅
- `yarn test` ✅ (83/83)
- Manual check: `foo(){ echo ${1:t}; }` → `foo() { echo ${1:t}; }`, `${0:A:h:h}` preserved.

## 📝 Notes

- The `LangVariant` numeric values changed upstream (now `1 << iota` bit flags), but this plugin references the exported constants, so no numeric values are hard-coded here.
- No new file type/extension is registered — this only adds the zsh parser *variant* — so the generated `languages.ts` is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Zsh shell dialect in shell formatting.

* **Bug Fixes**
  * Improved handling of Zsh-style modifier chains so they format correctly.
  * Updated an error message expectation to match the latest output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->